### PR TITLE
Support for 3rd party applications on workplace

### DIFF
--- a/DB/sessionsDB.js
+++ b/DB/sessionsDB.js
@@ -57,15 +57,17 @@ class SessionsDB {
 	removeSessionsByCommunity(communityId) {
 		let self = this
         return new Promise(function (resolve, reject) {
-			var meetingsRef = self.db.ref(ACTIVE_SESSIONS).orderByChild('communityId').equalTo(communityId)
+			var meetingsRef = self.db.ref(ACTIVE_SESSIONS).orderByChild('community').equalTo(communityId)
             .on("value", function(response) {
 				var value = response.val();
 				console.log("removeSessionByCommunity", value)
                     if (value) {
-                        resolve(Object.values(value))
-                    } else {
-                        resolve(null)
-                    }
+						for (var i = 0; i <Object.values(value).length; i++ ) {
+							var objRef =  self.db.ref(ACTIVE_SESSIONS).child(Object.keys(value)[i])
+							objRef.remove()
+						}
+					}
+                    resolve(null)
             })
         });
 	}

--- a/DB/sessionsDB.js
+++ b/DB/sessionsDB.js
@@ -54,7 +54,7 @@ class SessionsDB {
 		})
 	}
 
-	removeSessionByCommunity(communityId) {
+	removeSessionsByCommunity(communityId) {
 		let self = this
         return new Promise(function (resolve, reject) {
 			var meetingsRef = self.db.ref(ACTIVE_SESSIONS).orderByChild('communityId').equalTo(communityId)

--- a/DB/sessionsDB.js
+++ b/DB/sessionsDB.js
@@ -58,7 +58,7 @@ class SessionsDB {
 		let self = this
         return new Promise(function (resolve, reject) {
 			var meetingsRef = self.db.ref(ACTIVE_SESSIONS).orderByChild('community').equalTo(communityId)
-            .on("value", function(response) {
+            .once("value", function(response) {
 				var value = response.val();
 				console.log("removeSessionByCommunity", value)
 				if (value) {

--- a/DB/sessionsDB.js
+++ b/DB/sessionsDB.js
@@ -54,6 +54,22 @@ class SessionsDB {
 		})
 	}
 
+	removeSessionByCommunity(communityId) {
+		let self = this
+        return new Promise(function (resolve, reject) {
+			var meetingsRef = self.db.ref(ACTIVE_SESSIONS).orderByChild('communityId').equalTo(communityId)
+            .on("value", function(response) {
+				var value = response.val();
+				console.log("removeSessionByCommunity", value)
+                    if (value) {
+                        resolve(Object.values(value))
+                    } else {
+                        resolve(null)
+                    }
+            })
+        });
+	}
+
 }
 
 //var sessionsDB = new SessionsDB()

--- a/DB/sessionsDB.js
+++ b/DB/sessionsDB.js
@@ -61,13 +61,13 @@ class SessionsDB {
             .on("value", function(response) {
 				var value = response.val();
 				console.log("removeSessionByCommunity", value)
-                    if (value) {
-						for (var i = 0; i <Object.values(value).length; i++ ) {
-							var objRef =  self.db.ref(ACTIVE_SESSIONS).child(Object.keys(value)[i])
-							objRef.remove()
-						}
+				if (value) {
+					for (var i = 0; i <Object.values(value).length; i++ ) {
+						var objRef =  self.db.ref(ACTIVE_SESSIONS).child(Object.keys(value)[i])
+						objRef.remove()
 					}
-                    resolve(null)
+				}
+				resolve(null)
             })
         });
 	}

--- a/DB/tokenDB.js
+++ b/DB/tokenDB.js
@@ -9,21 +9,9 @@ class TokenDB {
     saveAccessToken(companyData) {
 		let self = this
 		return new Promise(resolve => {
-			var usersRef = self.db.ref(TOKENS_DB_NAME).child(companyData['id'])
-			usersRef.once("value")
-				.then(snapshot => {
-					var value = snapshot.val()
-					if (value) {
-						usersRef.update(companyData)
-						usersRef.once("value", snapshot => {
-							resolve(snapshot.val())
-						})
-	
-					} else {
-						self.db.ref(TOKENS_DB_NAME).child(companyData['id']).set(companyData)
-						resolve(companyData)
-					}
-				})
+			var companyRef = self.db.ref(TOKENS_DB_NAME).child(companyData['id'])
+			companyRef.set(companyData)
+			resolve(companyData)
 		})
 	
 	}

--- a/DB/tokenDB.js
+++ b/DB/tokenDB.js
@@ -1,0 +1,52 @@
+const TOKENS_DB_NAME = "Tokens"
+
+class TokenDB {
+
+	constructor (db) {
+		this.db = db
+    } 
+    
+    saveAccessToken(companyData) {
+		let self = this
+		return new Promise(resolve => {
+			var usersRef = self.db.ref(TOKENS_DB_NAME).child(companyData['id'])
+			usersRef.once("value")
+				.then(snapshot => {
+					var value = snapshot.val()
+					if (value) {
+						usersRef.update(companyData)
+						usersRef.once("value", snapshot => {
+							resolve(snapshot.val())
+						})
+	
+					} else {
+						self.db.ref(TOKENS_DB_NAME).child(companyData['id']).set(companyData)
+						resolve(companyData)
+					}
+				})
+		})
+	
+	}
+
+	getAccessToken(communityId) {
+		let self = this
+		return new Promise( resolve => {
+			if (!communityId) {
+				resolve()
+				return
+			}
+			var usersRef = self.db.ref(TOKENS_DB_NAME).child(communityId)
+			usersRef.once("value")
+				.then(snapshot => {
+					var value = snapshot.val()
+					resolve(value)
+				}).catch(error => {
+					resolve()
+				})
+		})
+	}
+
+}
+
+//var sessionsDB = new SessionsDB()
+module.exports = TokenDB

--- a/DB/tokenDB.js
+++ b/DB/tokenDB.js
@@ -34,7 +34,19 @@ class TokenDB {
 		})
 	}
 
+	removeAccessToken(communityId) {
+		let self = this
+		return new Promise( resolve => {    
+			var ref = self.db.ref(ACTIVE_SESSIONS)
+			var tokenRef = self.db.ref(TOKENS_DB_NAME).child(communityId)
+			tokenRef.remove()
+			resolve(communityId)
+		})
+	}
+
+
 }
+
 
 //var sessionsDB = new SessionsDB()
 module.exports = TokenDB

--- a/DB/tokenDB.js
+++ b/DB/tokenDB.js
@@ -37,7 +37,6 @@ class TokenDB {
 	removeAccessToken(communityId) {
 		let self = this
 		return new Promise( resolve => {    
-			var ref = self.db.ref(ACTIVE_SESSIONS)
 			var tokenRef = self.db.ref(TOKENS_DB_NAME).child(communityId)
 			tokenRef.remove()
 			resolve(communityId)

--- a/channels/facebook/fbmhook.js
+++ b/channels/facebook/fbmhook.js
@@ -112,7 +112,7 @@ const receivedMessage = (messagingEvent) => {
 		}
 
 		if (messagingEvent.sender.community ) {
-			messagingEvent.community = messagingEvent.sender.community
+			messagingEvent.community = messagingEvent.sender.community.id
 		}
 
 		sessionsManager.handleInboundChannelMessage(inboundMessage)

--- a/channels/facebook/fbmhook.js
+++ b/channels/facebook/fbmhook.js
@@ -111,6 +111,10 @@ const receivedMessage = (messagingEvent) => {
 			quick_reply: messagingEvent.message.quick_reply
 		}
 
+		if (messagingEvent.sender.community ) {
+			messagingEvent.community = messagingEvent.sender.community
+		}
+
 		sessionsManager.handleInboundChannelMessage(inboundMessage)
 	}
 	else if (messagingEvent.message.attachments) {
@@ -185,12 +189,12 @@ const receivedAccountLink = (event) => {
 	}
 }
 
-const getUserProfile = (userId) => {
-	return utility.getUserProfile(userId, "first_name,last_name,profile_pic,locale,timezone,gender,is_payment_enabled", MESSENGER_PAGE_ACCESS_TOKEN)
+const getUserProfile = (userId, accessToken = MESSENGER_PAGE_ACCESS_TOKEN) => {
+	return utility.getUserProfile(userId, "first_name,last_name,profile_pic,locale,timezone,gender,is_payment_enabled", accessToken)
 }
 
-const sendProfileApiBatch = (profile, path) => {
-	utility.sendProfileApiBatch(profile, path, MESSENGER_PAGE_ACCESS_TOKEN)
+const sendProfileApiBatch = (profile, path, accessToken = MESSENGER_PAGE_ACCESS_TOKEN) => {
+	utility.sendProfileApiBatch(profile, path, accessToken)
 }
 
 module.exports.handleInboundEvent = handleInboundEvent

--- a/channels/facebook/utility.js
+++ b/channels/facebook/utility.js
@@ -333,7 +333,7 @@ function sendAccountLinking(recipientId, accessToken) {
 function callMessageAPI(messageData, accessToken) {
 	var options = {
 		method: "POST",
-		uri: FACEBOOK_GRAPH_URL + "me/messages?access_token=" + accessToken ,
+		uri: FACEBOOK_GRAPH_URL + "me/messages?"+generateProof(accessToken) ,
 		headers: { "Content-Type": "application/json", "Accept": "application/json" },
 		body: messageData,
 		json: true
@@ -358,9 +358,10 @@ function getUserProfile(userId, fields, accessToken) {
 		if ( !userId ) {
 			return resolve({})
 		}
+
 		var options = {
 			method: "GET",
-			uri: FACEBOOK_GRAPH_URL + userId + "?fields=" + fields + "&access_token=" + accessToken ,
+			uri: FACEBOOK_GRAPH_URL + userId + "?fields=" + fields + "&"+generateProof(accessToken) ,
 			headers: { "Content-Type": "application/json", "Accept": "application/json" },
 			json: true
 		}
@@ -380,7 +381,7 @@ var sendNewPostToGroup = (groupId, message, accessToken) => {
 	return new Promise(resolve => {
 		var options = {
 			method: "POST",
-			uri: FACEBOOK_GRAPH_URL + groupId + "/feed?access_token=" + accessToken + "&message=" + message ,
+			uri: FACEBOOK_GRAPH_URL + groupId + "/feed?" + generateProof(accessToken)+"&message=" + message ,
 			headers: { "Content-Type": "application/json", "Accept": "application/json" },
 		}
 		rpn(options)
@@ -399,7 +400,7 @@ var sendCommentToPost = (postId, message, accessToken) => {
 	return new Promise(resolve => {
 		var options = {
 			method: "POST",
-			uri: FACEBOOK_GRAPH_URL + postId + "/comments?access_token=" + accessToken + "&message=" + message ,
+			uri: FACEBOOK_GRAPH_URL + postId + "/comments?"+generateProof(accessToken)+ "&message=" + message ,
 			headers: { "Content-Type": "application/json", "Accept": "application/json" },
 		}
 
@@ -435,7 +436,7 @@ var verifySubscription = (req, res) => {
 var getCommunity = (accessToken) => {
 	return new Promise( resolve => {
 		var options = {
-			uri: FACEBOOK_GRAPH_URL + "/community?access_token=" + accessToken,
+			uri: FACEBOOK_GRAPH_URL + "/community?"+generateProof(accessToken),
 			headers: { "Content-Type": "application/json", "Accept": "application/json" },
 		}
 
@@ -453,7 +454,7 @@ var getMembers = (community_id, next = null, limit, accessToken) => {
 	return new Promise( resolve => {
 		let fields = "title, department, name, location, locale, email, primary_phone"
 		var options = {      
-			uri: (next != null) ? next : FACEBOOK_GRAPH_URL + community_id + "/members?limit=" + limit + "&fields=" + fields +"&access_token=" + accessToken,
+			uri: (next != null) ? next : FACEBOOK_GRAPH_URL + community_id + "/members?limit=" + limit + "&fields=" + fields +"&" + generateProof(accessToken),
 			headers: { "Content-Type": "application/json", "Accept": "application/json" },
 		}
 
@@ -541,8 +542,17 @@ var getCompany = (accessToken) => {
 	})
 
 }
-
+/**
+ * 
+ * For Production installs of Application, 
+ * FB reqires sending the access_token as well as hash of the key/secret
+ * This is ONLY used in production apps
+ * see https://developers.facebook.com/docs/workplace/integrations/third-party
+ */
 var generateProof = (accessToken) => {
+	if (process.env.DEV_INTERGRATION) {
+		return 'access_token=' + accessToken 
+	}
 	const appsecretTime = moment().unix() - 5;
 	const appsecretProof = crypto
 		.createHmac('sha256', process.env.MESSENGER_APP_SECRET)

--- a/channels/facebook/utility.js
+++ b/channels/facebook/utility.js
@@ -37,6 +37,26 @@ const sendProfileApiBatch = ( propertyBody, path = "me", accessToken) => {
 		})
 }
 
+const getProfileApiBatch = (keys, path = "me", accessToken) => {
+	return new Promise(function (resolve, reject) {
+		var options = {
+			method: "GET",
+			uri:FACEBOOK_GRAPH_URL+path+"?fields="+keys+"&"+generateProof(accessToken),
+
+		}
+		rpn(options)
+			.then( json => {
+				console.log("getProfileApiBatch returned: ",json)
+				resolve(JSON.parse(json))
+			})
+			.catch( err => {
+				console.log("getProfileApiBatch returned error: " + err)
+				reject(err)
+			})
+		})
+
+}
+
 /*
  * Verify that the callback came from Facebook. Using the App Secret from 
  * the App Dashboard, we can verify the signature that is sent with each 
@@ -563,7 +583,7 @@ var generateProof = (accessToken) => {
 
 
 module.exports = {
-	PROFILE_API, sendProfileApiBatch, getUserProfile, sendNewPostToGroup, sendCommentToPost,
+	PROFILE_API, sendProfileApiBatch, getProfileApiBatch, getUserProfile, sendNewPostToGroup, sendCommentToPost,
 	sendTextMessage, sendQuickReply, sendGenericMessage, sendCustomMessage, sendImageMessage, sendAccountLinking, 
 	verifyWithChannelAppSecretHandler, verifySubscription, 
 	receivedDeliveryConfirmation, receivedAuthentication, receivedMessageRead,

--- a/channels/facebook/utility.js
+++ b/channels/facebook/utility.js
@@ -159,6 +159,7 @@ function receivedMessageRead(event) {
 
 function sendTextMessage(recipientId, text, accessToken) {
 	var messageData = {
+		messaging_type:"RESPONSE",
 		recipient: {
 			id: recipientId
 		},
@@ -200,6 +201,7 @@ function sendGenericMessage(recipientId, title, subtitle, imageUrl, buttons, acc
 	if (buttons && buttons.length > 0) element.buttons = buttons
 
 	var messageData = {
+		messaging_type:"RESPONSE",
 		recipient: {
 			id: recipientId
 		},
@@ -219,6 +221,7 @@ function sendGenericMessage(recipientId, title, subtitle, imageUrl, buttons, acc
 
 function sendCustomMessage(recipientId, messageObject, accessToken) {
 	var messageData = {
+		messaging_type:"RESPONSE",
 		recipient: {
 			id: recipientId
 		},
@@ -230,6 +233,7 @@ function sendCustomMessage(recipientId, messageObject, accessToken) {
 
 function sendQuickReply(recipientId, title, quickReplies, accessToken) {
 	var messageData = {
+		messaging_type:"RESPONSE",
 		recipient: {
 			id: recipientId
 		},
@@ -255,6 +259,7 @@ function sendQuickReply(recipientId, title, quickReplies, accessToken) {
 
 function sendImageMessage(recipientId, url, accessToken) {
 	var messageData = {
+		messaging_type:"RESPONSE",
 		recipient: {
 			id: recipientId
 		},
@@ -317,6 +322,7 @@ function sendTypingOff(recipientId, accessToken) {
  */
 function sendAccountLinking(recipientId, accessToken) {
 	var messageData = {
+		messaging_type:"RESPONSE",
 		recipient: {
 			id: recipientId
 		},

--- a/channels/facebook/utility.js
+++ b/channels/facebook/utility.js
@@ -590,6 +590,27 @@ var getGroupInfo = (groupId, accessToken) => {
 			})
 	})
 }
+
+var parseSignedRequest = (request) => {
+	return new Promise((resolve, reject) => {
+		var SignedRequest = require('facebook-signed-request');
+		console.log("signedRequest", request)
+		SignedRequest.secret = process.env.MESSENGER_APP_SECRET;
+		var signedRequest = new SignedRequest(request);
+		signedRequest.parse(function (errors, request) {
+			console.log(request.isValid());
+			console.log(request.data)
+			console.log(errors)
+
+			if (request.isValid()) {
+				resolve(request.data)
+			} else {
+				var error = new Error(errors.join(","))
+				reject(error)
+			}
+		});
+	});
+}
 /**
  * 
  * For Production installs of Application, 
@@ -616,5 +637,5 @@ module.exports = {
 	sendTextMessage, sendQuickReply, sendGenericMessage, sendCustomMessage, sendImageMessage, sendAccountLinking, 
 	verifyWithChannelAppSecretHandler, verifySubscription, 
 	receivedDeliveryConfirmation, receivedAuthentication, receivedMessageRead,
-	getCommunity, webhookSubscribe, getMembers, getAccessToken, getCompany, getGroupInfo, generateProof
+	getCommunity, webhookSubscribe, getMembers, getAccessToken, getCompany, getGroupInfo, parseSignedRequest, generateProof
 }

--- a/channels/facebook/utility.js
+++ b/channels/facebook/utility.js
@@ -158,6 +158,7 @@ function receivedMessageRead(event) {
 }
 
 function sendTextMessage(recipientId, text, accessToken) {
+	console.log("**sendTextMessage **")
 	var messageData = {
 		messaging_type:"RESPONSE",
 		recipient: {

--- a/channels/facebook/utility.js
+++ b/channels/facebook/utility.js
@@ -569,6 +569,27 @@ var getCompany = (accessToken) => {
 	})
 
 }
+
+var getGroupInfo = (groupId, accessToken) => {
+	return new Promise((resolve, reject) => {
+		var options = {
+			method: "GET",
+			uri: FACEBOOK_GRAPH_URL + groupId + "?"+generateProof(accessToken),
+			headers: { "Content-Type": "application/json", "Accept": "application/json" },
+		}
+
+		rpn(options)
+			.then(json => {
+				json = JSON.parse(json)
+				console.log("getGroupInfo", json)
+				return resolve(json)
+			})
+			.catch(err => {
+				console.error("getGroupInfo got an error:", err) /// show status code, status message and error
+				reject(err)
+			})
+	})
+}
 /**
  * 
  * For Production installs of Application, 
@@ -595,5 +616,5 @@ module.exports = {
 	sendTextMessage, sendQuickReply, sendGenericMessage, sendCustomMessage, sendImageMessage, sendAccountLinking, 
 	verifyWithChannelAppSecretHandler, verifySubscription, 
 	receivedDeliveryConfirmation, receivedAuthentication, receivedMessageRead,
-	getCommunity, webhookSubscribe, getMembers, getAccessToken, getCompany, generateProof
+	getCommunity, webhookSubscribe, getMembers, getAccessToken, getCompany, getGroupInfo, generateProof
 }

--- a/channels/facebook/utility.js
+++ b/channels/facebook/utility.js
@@ -9,7 +9,7 @@ const
 
 const AUTHORIZATION_URL = process.env.AUTHORIZATION_URL
 
-const FACEBOOK_GRAPH_URL = "https://graph.facebook.com/v2.10/"
+const FACEBOOK_GRAPH_URL = "https://graph.facebook.com/v2.12/"
 
 const PROFILE_API = {
 	PERSISTENT_MENU: "persistent_menu",

--- a/channels/facebook/utility.js
+++ b/channels/facebook/utility.js
@@ -158,7 +158,6 @@ function receivedMessageRead(event) {
 }
 
 function sendTextMessage(recipientId, text, accessToken) {
-	console.log("**sendTextMessage **")
 	var messageData = {
 		messaging_type:"RESPONSE",
 		recipient: {
@@ -194,8 +193,6 @@ function sendTextMessage(recipientId, text, accessToken) {
 } */
 
 function sendGenericMessage(recipientId, title, subtitle, imageUrl, buttons, accessToken) {
-	console.log("**sendGenericMessage **")
-
 	let element = {
 		title: title,
 		image_url: imageUrl,
@@ -223,7 +220,6 @@ function sendGenericMessage(recipientId, title, subtitle, imageUrl, buttons, acc
 }
 
 function sendCustomMessage(recipientId, messageObject, accessToken) {
-	console.log("**sendCustomMessage **")
 	var messageData = {
 		messaging_type:"RESPONSE",
 		recipient: {
@@ -236,8 +232,6 @@ function sendCustomMessage(recipientId, messageObject, accessToken) {
 }
 
 function sendQuickReply(recipientId, title, quickReplies, accessToken) {
-	console.log("**sendQuickReply **")
-
 	var messageData = {
 		messaging_type:"RESPONSE",
 		recipient: {
@@ -397,7 +391,6 @@ function getUserProfile(userId, fields, accessToken) {
 			headers: { "Content-Type": "application/json", "Accept": "application/json" },
 			json: true
 		}
-		console.log('getUserProfile options',options)
   
 		rpn(options)
 			.then( json => {

--- a/channels/facebook/utility.js
+++ b/channels/facebook/utility.js
@@ -598,11 +598,12 @@ var parseSignedRequest = (request) => {
 		SignedRequest.secret = process.env.MESSENGER_APP_SECRET;
 		var signedRequest = new SignedRequest(request);
 		signedRequest.parse(function (errors, request) {
+			
 			console.log(request.isValid());
 			console.log(request.data)
 			console.log(errors)
 
-			if (request.isValid()) {
+			if (request.data) {
 				resolve(request.data)
 			} else {
 				var error = new Error(errors.join(","))

--- a/channels/facebook/utility.js
+++ b/channels/facebook/utility.js
@@ -460,7 +460,7 @@ var verifySubscription = (req, res) => {
 }
 
 var getCommunity = (accessToken) => {
-	return new Promise( resolve => {
+	return new Promise( (resolve, reject) => {
 		var options = {
 			uri: FACEBOOK_GRAPH_URL + "/community?"+generateProof(accessToken),
 			headers: { "Content-Type": "application/json", "Accept": "application/json" },
@@ -468,10 +468,11 @@ var getCommunity = (accessToken) => {
 
 		rpn(options)
 			.then( json => {
-				return resolve(JSON.parse(json))
+				resolve(JSON.parse(json))
 			})
-			.catch(err => {
-				console.error("getCommunity got an error:", err) /// show status code, status message and error
+			.catch(error => {
+				console.error("getCommunity got an error:", error) /// show status code, status message and error
+				reject(error)
 			})
 	})
 }

--- a/channels/facebook/utility.js
+++ b/channels/facebook/utility.js
@@ -194,6 +194,8 @@ function sendTextMessage(recipientId, text, accessToken) {
 } */
 
 function sendGenericMessage(recipientId, title, subtitle, imageUrl, buttons, accessToken) {
+	console.log("**sendGenericMessage **")
+
 	let element = {
 		title: title,
 		image_url: imageUrl,
@@ -221,6 +223,7 @@ function sendGenericMessage(recipientId, title, subtitle, imageUrl, buttons, acc
 }
 
 function sendCustomMessage(recipientId, messageObject, accessToken) {
+	console.log("**sendCustomMessage **")
 	var messageData = {
 		messaging_type:"RESPONSE",
 		recipient: {
@@ -233,6 +236,8 @@ function sendCustomMessage(recipientId, messageObject, accessToken) {
 }
 
 function sendQuickReply(recipientId, title, quickReplies, accessToken) {
+	console.log("**sendQuickReply **")
+
 	var messageData = {
 		messaging_type:"RESPONSE",
 		recipient: {
@@ -392,6 +397,7 @@ function getUserProfile(userId, fields, accessToken) {
 			headers: { "Content-Type": "application/json", "Accept": "application/json" },
 			json: true
 		}
+		console.log('getUserProfile options',options)
   
 		rpn(options)
 			.then( json => {

--- a/channels/facebook/utility.js
+++ b/channels/facebook/utility.js
@@ -488,6 +488,60 @@ var webhookSubscribe = () => {
 	})
 }
 
+var getAccessToken = (code) => {
+
+	return new Promise((resolve, reject) => {
+		const clientID = process.env.MESSENGER_APP_ID
+		const clientSecret = process.env.MESSENGER_APP_SECRET
+		const redirectURL = process.env.REDIRECT_URL
+		var options = {
+			method: "GET",
+			uri: FACEBOOK_GRAPH_URL + 'oauth/access_token?' + 'client_id=' + clientID + "&client_secret=" + clientSecret + "&redirect_uri=" + redirectURL + "&code=" + code,
+			headers: { "Content-Type": "application/json", "Accept": "application/json" },
+		}
+
+		rpn(options)
+			.then(json => {
+				json = JSON.parse(json)
+				console.log("getAccessToken", json)
+				var access_token = json['access_token']
+				return resolve(access_token)
+			})
+			.catch(err => {
+				console.error("getAccessToken got an error:", err) /// show status code, status message and error
+				reject(err)
+			})
+	})
+
+}
+
+var getCompany = (accessToken) => {
+
+	return new Promise((resolve, reject) => {
+		const clientID = process.env.MESSENGER_APP_ID
+		const clientSecret = process.env.MESSENGER_APP_SECRET
+		const redirectURL = process.env.REDIRECT_URL
+		var options = {
+			method: "GET",
+			uri: FACEBOOK_GRAPH_URL + 'company?' + "fields=name&" + generateProof(accessToken),
+			headers: { "Content-Type": "application/json", "Accept": "application/json" },
+		}
+
+		rpn(options)
+			.then(json => {
+				json = JSON.parse(json)
+				console.log("getCompany", json)
+				json['access_token'] = accessToken
+				return resolve(json)
+			})
+			.catch(err => {
+				console.error("getCompany got an error:", err) /// show status code, status message and error
+				reject(err)
+			})
+	})
+
+}
+
 var generateProof = (accessToken) => {
 	const appsecretTime = moment().unix() - 5;
 	const appsecretProof = crypto
@@ -503,5 +557,5 @@ module.exports = {
 	sendTextMessage, sendQuickReply, sendGenericMessage, sendCustomMessage, sendImageMessage, sendAccountLinking, 
 	verifyWithChannelAppSecretHandler, verifySubscription, 
 	receivedDeliveryConfirmation, receivedAuthentication, receivedMessageRead,
-	getCommunity, webhookSubscribe, getMembers, generateProof
+	getCommunity, webhookSubscribe, getMembers, getAccessToken, getCompany, generateProof
 }

--- a/channels/facebook/utility.js
+++ b/channels/facebook/utility.js
@@ -573,11 +573,12 @@ var generateProof = (accessToken) => {
 	if (!process.env.WP_PRODUCTION) {
 		return 'access_token=' + accessToken 
 	}
-	const appsecretTime = moment().unix() - 5;
-	const appsecretProof = crypto
-		.createHmac('sha256', process.env.MESSENGER_APP_SECRET)
-		.update(accessToken + '|' + appsecretTime)
-		.digest('hex');
+	
+	const appsecretTime = Math.floor(Date.now() / 1000) - 10;
+    const appsecretProof = crypto
+        .createHmac('sha256', process.env.MESSENGER_APP_SECRET)
+        .update(accessToken + '|' + appsecretTime)
+        .digest('hex');
 	return 'access_token=' + accessToken + '&appsecret_proof=' + appsecretProof + '&appsecret_time=' + appsecretTime
 }
 

--- a/channels/facebook/utility.js
+++ b/channels/facebook/utility.js
@@ -570,7 +570,7 @@ var getCompany = (accessToken) => {
  * see https://developers.facebook.com/docs/workplace/integrations/third-party
  */
 var generateProof = (accessToken) => {
-	if (process.env.DEV_INTERGRATION) {
+	if (!process.env.WP_PRODUCTION) {
 		return 'access_token=' + accessToken 
 	}
 	const appsecretTime = moment().unix() - 5;

--- a/channels/facebook/wphook.js
+++ b/channels/facebook/wphook.js
@@ -126,10 +126,17 @@ function processPageEvents(data) {
 					channel: sessionsManager.CHANNELS.FB_WORKPLACE,
 					sourceType: sessionsManager.SOURCE_TYPE.POST,
 					source: change.value.post_id,
-					from: change.value.sender_id, 
+					from: change.value.sender_id || change.value.from.id, 
 					to: pageID,
 					text: change.value.message.substring(change.value.message.indexOf(" ") + 1)
 				}
+
+				if (process.env.WP_PRODUCTION) {
+					inboundMessage.community = change.value.community
+					console.log("inboundMessage.community ", inboundMessage.community);
+
+				}
+
 				sessionsManager.handleInboundChannelMessage(inboundMessage)
 			})
 		}
@@ -155,6 +162,7 @@ const handleInstallEvent = (req, res) => {
 			}).then((json) => {
 				return tokenDB.saveAccessToken(json)
 			}).then((json) => {
+				console.log("saving access token", json['access_token'])
 				_json = json
 				const profile = require('../../../profile').profile
 				return sendProfileApiBatch(profile, "me/messenger_profile", json['access_token']) 
@@ -187,6 +195,8 @@ const receivedMessage = (messagingEvent, pageID) => {
 		}
 
 		if (process.env.WP_PRODUCTION) {
+			console.log("inboundMessage.community ", inboundMessage.community);
+
 			inboundMessage.community = messagingEvent.sender.community
 		}
 
@@ -224,6 +234,7 @@ const receivedPostback = (messagingEvent) => {
 		
 	}
 	if (process.env.WP_PRODUCTION) {
+		console.log("inboundPostbackMessage.community ", inboundPostbackMessage.community);
 		inboundPostbackMessage.community = messagingEvent.sender.community
 	}
 

--- a/channels/facebook/wphook.js
+++ b/channels/facebook/wphook.js
@@ -364,6 +364,10 @@ const generateProof = (accessToken) => {
 	return utility.generateProof(accessToken)
 }
 
+const parseSignedRequest = (signedRequest) => {
+	return utility.parseSignedRequest(signedRequest)
+}
+
 module.exports.handleInboundEvent = handleInboundEvent
 module.exports.handleInboundInstallEvent = handleInboundInstallEvent
 module.exports.handleInboundUninstallEvent = handleInboundUninstallEvent
@@ -379,3 +383,4 @@ module.exports.getCommunity = getCommunity
 module.exports.getGroupInfo = getGroupInfo
 module.exports.webhookSubscribe = webhookSubscribe
 module.exports.generateProof = generateProof
+module.exports.parseSignedRequest = parseSignedRequest

--- a/channels/facebook/wphook.js
+++ b/channels/facebook/wphook.js
@@ -272,7 +272,7 @@ function processWorkplaceSecurityEvents(data) {
 function sendMessage(messageObj, session) {
 
 	var accessToken = WORKPLACE_PAGE_ACCESS_TOKEN
-	if (session.communityAccessToken) {
+	if (process.env.WP_PRODUCTION && session.communityAccessToken) {
 		accessToken = session.communityAccessToken
 	}
 

--- a/channels/facebook/wphook.js
+++ b/channels/facebook/wphook.js
@@ -272,8 +272,8 @@ function processWorkplaceSecurityEvents(data) {
 function sendMessage(messageObj, session) {
 
 	var accessToken = WORKPLACE_PAGE_ACCESS_TOKEN
-	if (process.env.WP_PRODUCTION && session.community.access_token) {
-		accessToken = session.community.access_token
+	if (process.env.WP_PRODUCTION && session.communityAccessToken) {
+		accessToken = session.communityAccessToken
 	}
 
 	if (session.sourceType) {

--- a/channels/facebook/wphook.js
+++ b/channels/facebook/wphook.js
@@ -336,10 +336,10 @@ const getProfileApiBatch = (keys, path, accessToken = WORKPLACE_PAGE_ACCESS_TOKE
 const getCommunity = (accessToken = WORKPLACE_PAGE_ACCESS_TOKEN) => {
 	return new Promise( resolve => {
 		if ( community ) { 
-			return Promise.resolve(community)
+			resolve(community)
 		}
 		else {
-			utility.getCommunity(accessToken)
+			return utility.getCommunity(accessToken)
 				.then(communityResult => {
 					community = communityResult
 					resolve(community)

--- a/channels/facebook/wphook.js
+++ b/channels/facebook/wphook.js
@@ -252,7 +252,7 @@ function sendTextMessageToExistingGroup(threadId, message) {
 }
 
 const getUserProfile = userId => {
-	return utility.getUserProfile(userId, "first_name,last_name", WORKPLACE_PAGE_ACCESS_TOKEN)
+	return utility.getUserProfile(userId, "first_name, last_name, email", WORKPLACE_PAGE_ACCESS_TOKEN)
 }
 
 const sendProfileApiBatch = (profile, path) => {

--- a/channels/facebook/wphook.js
+++ b/channels/facebook/wphook.js
@@ -132,7 +132,7 @@ function processPageEvents(data) {
 				}
 
 				if (process.env.WP_PRODUCTION) {
-					inboundMessage.community = change.value.community
+					inboundMessage.community = change.value.community.id
 					console.log("inboundMessage.community ", inboundMessage.community);
 
 				}
@@ -197,7 +197,7 @@ const receivedMessage = (messagingEvent, pageID) => {
 		if (process.env.WP_PRODUCTION) {
 			console.log("inboundMessage.community ", inboundMessage.community);
 
-			inboundMessage.community = messagingEvent.sender.community
+			inboundMessage.community = messagingEvent.sender.community.id
 		}
 
 		sessionsManager.handleInboundChannelMessage(inboundMessage)
@@ -235,7 +235,7 @@ const receivedPostback = (messagingEvent) => {
 	}
 	if (process.env.WP_PRODUCTION) {
 		console.log("inboundPostbackMessage.community ", inboundPostbackMessage.community);
-		inboundPostbackMessage.community = messagingEvent.sender.community
+		inboundPostbackMessage.community = messagingEvent.sender.community.id
 	}
 
 	/// TODO: promisfy this to send the 200 response back as quickly as possible

--- a/channels/facebook/wphook.js
+++ b/channels/facebook/wphook.js
@@ -347,6 +347,14 @@ const getCommunity = (accessToken = WORKPLACE_PAGE_ACCESS_TOKEN) => {
 		}
 	})
 }
+const getGroupInfo = (groupId, accessToken = WORKPLACE_PAGE_ACCESS_TOKEN) => {
+	return new Promise( resolve => {
+	utility.getGroupInfo(groupId, accessToken)
+		.then(groupInfo => {
+			resolve(groupInfo)
+		})
+	})
+}
 
 const webhookSubscribe = () => {
 	utility.webhookSubscribe()
@@ -368,5 +376,6 @@ module.exports.sendProfileApiBatch = sendProfileApiBatch
 module.exports.getProfileApiBatch = getProfileApiBatch
 
 module.exports.getCommunity = getCommunity
+module.exports.getGroupInfo = getGroupInfo
 module.exports.webhookSubscribe = webhookSubscribe
 module.exports.generateProof = generateProof

--- a/channels/facebook/wphook.js
+++ b/channels/facebook/wphook.js
@@ -298,7 +298,7 @@ function sendNewPostToGroup(groupId, message, accessToken = WORKPLACE_PAGE_ACCES
 }
 
 function sendCommentToPost(postId, message, accessToken = WORKPLACE_PAGE_ACCESS_TOKEN ) {
-	return utility.sendCommentToPost(postId, message, access_token)
+	return utility.sendCommentToPost(postId, message, accessToken)
 }
 
 function sendTextMessageToExistingGroup(threadId, message, accessToken = WORKPLACE_PAGE_ACCESS_TOKEN) {

--- a/channels/facebook/wphook.js
+++ b/channels/facebook/wphook.js
@@ -175,7 +175,7 @@ const receivedMessage = (messagingEvent, pageID) => {
 			text: messagingEvent.message.text
 		}
 
-		if (!process.env.DEV_INTERGRATION) {
+		if (process.env.WP_PRODUCTION) {
 			inboundMessage.community = messagingEvent.sender.community
 		}
 
@@ -212,7 +212,7 @@ const receivedPostback = (messagingEvent) => {
 		payload: payload,
 		
 	}
-	if (!process.env.DEV_INTERGRATION) {
+	if (process.env.WP_PRODUCTION) {
 		inboundPostbackMessage.community = messagingEvent.sender.community
 	}
 

--- a/channels/facebook/wphook.js
+++ b/channels/facebook/wphook.js
@@ -138,12 +138,17 @@ function processPageEvents(data) {
 
 const handleInstallEvent = (req, res) => {
 	return new Promise((resolve, reject) => {
-		if (!req.query.code) {
+		
+		if (!req.query.code && !req.params['code']) {
 			console.error('No code received.')
 			reject()
 			return
 		}
 		var _json;
+		var code = req.query.code
+		if (req.params['code']) {
+			code = req.params['code'].replace("code=", "")
+		}
 		utility.getAccessToken(req.query.code)
 			.then((accessToken) => {
 				return utility.getCompany(accessToken)

--- a/channels/facebook/wphook.js
+++ b/channels/facebook/wphook.js
@@ -255,8 +255,8 @@ const getUserProfile = userId => {
 	return utility.getUserProfile(userId, "first_name, last_name, email", WORKPLACE_PAGE_ACCESS_TOKEN)
 }
 
-const sendProfileApiBatch = (profile, path) => {
-	utility.sendProfileApiBatch(profile, path, WORKPLACE_PAGE_ACCESS_TOKEN)
+const sendProfileApiBatch = (profile, path, accessToken = WORKPLACE_PAGE_ACCESS_TOKEN) => {
+	utility.sendProfileApiBatch(profile, path, accessToken)
 }
 
 const getCommunity = () => {
@@ -274,6 +274,14 @@ const getCommunity = () => {
 	})
 }
 
+const webhookSubscribe = () => {
+	utility.webhookSubscribe()
+}
+
+const generateProof = (accessToken) => {
+	return utility.generateProof(accessToken)
+}
+
 module.exports.handleInboundEvent = handleInboundEvent
 module.exports.sendMessage = sendMessage
 module.exports.sendNewPostToGroup = sendNewPostToGroup
@@ -281,3 +289,5 @@ module.exports.getUserProfile = getUserProfile
 module.exports.startChannel = startChannel
 module.exports.sendProfileApiBatch = sendProfileApiBatch
 module.exports.getCommunity = getCommunity
+module.exports.webhookSubscribe = webhookSubscribe
+module.exports.generateProof = generateProof

--- a/channels/facebook/wphook.js
+++ b/channels/facebook/wphook.js
@@ -306,6 +306,10 @@ const getUserProfile = (userId, accessToken = WORKPLACE_PAGE_ACCESS_TOKEN) => {
 const sendProfileApiBatch = (profile, path, accessToken = WORKPLACE_PAGE_ACCESS_TOKEN) => {
 	utility.sendProfileApiBatch(profile, path, accessToken)
 }
+const getProfileApiBatch = (keys, path, accessToken = WORKPLACE_PAGE_ACCESS_TOKEN) => {
+	return utility.getProfileApiBatch(keys, path, accessToken)
+}
+
 
 const getCommunity = (accessToken = WORKPLACE_PAGE_ACCESS_TOKEN) => {
 	return new Promise( resolve => {
@@ -337,6 +341,8 @@ module.exports.sendNewPostToGroup = sendNewPostToGroup
 module.exports.getUserProfile = getUserProfile
 module.exports.startChannel = startChannel
 module.exports.sendProfileApiBatch = sendProfileApiBatch
+module.exports.getProfileApiBatch = getProfileApiBatch
+
 module.exports.getCommunity = getCommunity
 module.exports.webhookSubscribe = webhookSubscribe
 module.exports.generateProof = generateProof

--- a/channels/facebook/wphook.js
+++ b/channels/facebook/wphook.js
@@ -272,8 +272,8 @@ function processWorkplaceSecurityEvents(data) {
 function sendMessage(messageObj, session) {
 
 	var accessToken = WORKPLACE_PAGE_ACCESS_TOKEN
-	if (process.env.WP_PRODUCTION && session.communityAccessToken) {
-		accessToken = session.communityAccessToken
+	if (process.env.WP_PRODUCTION && session.community.access_token) {
+		accessToken = session.community.access_token
 	}
 
 	if (session.sourceType) {

--- a/channels/facebook/wphook.js
+++ b/channels/facebook/wphook.js
@@ -39,6 +39,10 @@ var handleInboundEvent = function (req, res) {
 var handleInboundInstallEvent = function (req, res) {
 	return handleInstallEvent(req, res)
 }
+var handleInboundUninstallEvent = function (req, res) {
+	return handleUninstallEvent(req, res)
+}
+
 /*
  * All callbacks for webhooks are POST-ed. They will be sent to the same
  * webhook. Be sure to subscribe your app to your page to receive callbacks.
@@ -155,8 +159,10 @@ const handleInstallEvent = (req, res) => {
 				reject(error)
 			})
 	});
-	
+}
 
+const handleUninstallEvent = (req, res) => {
+	//TODO wating on implmention from FB
 }
 
 const receivedMessage = (messagingEvent, pageID) => {
@@ -336,6 +342,8 @@ const generateProof = (accessToken) => {
 
 module.exports.handleInboundEvent = handleInboundEvent
 module.exports.handleInboundInstallEvent = handleInboundInstallEvent
+module.exports.handleInboundUninstallEvent = handleInboundUninstallEvent
+
 module.exports.sendMessage = sendMessage
 module.exports.sendNewPostToGroup = sendNewPostToGroup
 module.exports.getUserProfile = getUserProfile

--- a/sessionsManager.js
+++ b/sessionsManager.js
@@ -362,7 +362,8 @@ const postEventToSource = (sourceType, session, eventFunction, args=null, channe
 						}
 					})   
             }).then((session) => {
-                return removeSessionBySource(session.source)
+				resolve()
+                // return removeSessionBySource(session.source)
             }).then(() => {
                 resolve()
             })

--- a/sessionsManager.js
+++ b/sessionsManager.js
@@ -186,8 +186,7 @@ var getSessionByChannelEvent = (messagingEvent) => {
 				var access_token = process.env.WORKPLACE_PAGE_ACCESS_TOKEN
 				console.log("USING WORKPLACE_PAGE_ACCESS_TOKEN", access_token)
 				if (json) {
-					access_token = json.access_token
-					mappedChatSession.communityAccessToken = json.access_token
+					mappedChatSession.community = json
 				} 
 				console.log("mappedChatSession", mappedChatSession)
 				userChannelToSessions[messagingEvent.source] = mappedChatSession

--- a/sessionsManager.js
+++ b/sessionsManager.js
@@ -163,13 +163,16 @@ var getSessionByChannelEvent = (messagingEvent) => {
 			mappedChatSession.lastInboundMessage = moment().format("MMMM Do YYYY, h:mm:ss a")
 			
 			if ( messagingEvent.from ) {
-				updateSession(mappedChatSession, {from: messagingEvent.from})
+				mappedChatSession.from = messagingEvent.from 
 			}
 			if ( messagingEvent.data ) {
 				let mergedData = Object.assign(mappedChatSession.data, messagingEvent.data)
-				updateSession(mappedChatSession, {data: mergedData})
+				mappedChatSession.data = mergedData
 			}
-			return resolve(mappedChatSession)
+			sessionsDb.saveSession(mappedChatSession)
+			.then(() => {
+				return resolve(mappedChatSession)
+			})
 		}
 		else {
 			// Set new session 

--- a/sessionsManager.js
+++ b/sessionsManager.js
@@ -123,10 +123,12 @@ const getSessionBySessionId = sessionId => {
 	return chatSessions[sessionId]
 }
 
-const clearChatSessions = () => {
-	console.log("**Removing non-saved chat sessions")
+const clearChatSessions = (communityId) => {
+	console.log("**Removing chat sessions for community")
 	chatSessions = {}
 	userChannelToSessions = {}
+	sessionsDb.removeSessionsByCommunity(communityId)
+
 }
 
 /*
@@ -410,3 +412,4 @@ module.exports.updateSession = updateSession
 module.exports.getApiAiAgent = getApiAiAgent
 module.exports.getDB = getDB
 module.exports.clearChatSessions = clearChatSessions
+

--- a/sessionsManager.js
+++ b/sessionsManager.js
@@ -184,7 +184,7 @@ var getSessionByChannelEvent = (messagingEvent) => {
 			}
 
 			if (messagingEvent.community ) {
-				mappedChatSession.community = messagingEvent.community.toString()
+				mappedChatSession.community = String(messagingEvent.community)
 			}
 
 			var communityId = (typeof messagingEvent.community != "undefined") ? messagingEvent.community : null 

--- a/sessionsManager.js
+++ b/sessionsManager.js
@@ -185,11 +185,12 @@ var getSessionByChannelEvent = (messagingEvent) => {
 			tokensDb.getAccessToken(communityId)
 			.then(json => {
 				var access_token = process.env.WORKPLACE_PAGE_ACCESS_TOKEN
-				console.log("USING WORKPLACE_PAGE_ACCESS_TOKEN", access_token)
 				if (json) {
 					access_token = json.access_token
+					console.log("USING communityAccessToken", access_token)
 					mappedChatSession.communityAccessToken = json.access_token
-				} 
+				} else {
+				}
 				console.log("mappedChatSession", mappedChatSession)
 				userChannelToSessions[messagingEvent.source] = mappedChatSession
 				return getChannel(mappedChatSession.channelType).getUserProfile(mappedChatSession.from, access_token)

--- a/sessionsManager.js
+++ b/sessionsManager.js
@@ -127,7 +127,11 @@ const clearChatSessions = (communityId) => {
 	console.log("**Removing chat sessions for community")
 	chatSessions = {}
 	userChannelToSessions = {}
+
 	sessionsDb.removeSessionsByCommunity(communityId)
+	.then(() => {
+		return tokensDb.removeAccessToken(communityId)
+	})
 
 }
 

--- a/sessionsManager.js
+++ b/sessionsManager.js
@@ -367,7 +367,8 @@ const postEventToSource = (sourceType, session, eventFunction, channel) => {
 
 const createSessionByEvent = (session, sourceType, channel)  => {
     const messagingEvent = {
-        source: session.from,
+		source: session.from,
+		from: session.from,
         sourceType: sourceType,
         channel: channel,
         profile: session.profile

--- a/sessionsManager.js
+++ b/sessionsManager.js
@@ -128,13 +128,16 @@ const getSessionBySessionId = sessionId => {
 
 const clearChatSessions = (communityId) => {
 	console.log("**Removing chat sessions for community", communityId)
-	chatSessions = {}
-	userChannelToSessions = {}
 
-	// sessionsDb.removeSessionsByCommunity(communityId)
-	// .then(() => {
-	// 	return tokensDb.removeAccessToken(communityId)
-	// })
+
+	sessionsDb.removeSessionsByCommunity(communityId)
+	.then(() => {
+		return tokensDb.removeAccessToken(communityId)
+	}).then(() => {
+		chatSessions = {}
+		userChannelToSessions = {}
+		getAllActiveSessions()
+	})
 
 }
 

--- a/sessionsManager.js
+++ b/sessionsManager.js
@@ -334,6 +334,46 @@ const handleEvent = (session, event) => {
 			})
 	}
 }
+/**
+ * This allows Dialogflow events to be sent to different sources
+ * @param {*} session //orginal session
+ * @param {*} eventFunction  //function to call to act on new session
+ * @param {*} sourceType //source to post message to
+ * @param {*} channel //channel to post message to
+ */
+const postEventToSource = (sourceType, session, eventFunction, channel) => {
+	return new Promise(resolve => {
+        createSessionByEvent(session, sourceType, channel)
+            .then(session => {
+					return new Promise(resolve => {
+						if (eventFunction) {
+							console.log("calling function ", eventFunction)
+							eventFunction(session)
+							setTimeout(() => {
+								resolve(session)
+							}, 3000)
+						} else {
+							console.error("No function to call")
+							resolve(session)
+						}
+					})   
+            }).then((session) => {
+                return removeSessionBySource(session.source)
+            }).then(() => {
+                resolve()
+            })
+    })
+}
+
+const createSessionByEvent = (session, sourceType, channel)  => {
+    const messagingEvent = {
+        source: session.from,
+        sourceType: sourceType,
+        channel: channel,
+        profile: session.profile
+    }
+    return getSessionByChannelEvent(messagingEvent)
+}
 
 module.exports.handleInboundChannelPostback = handleInboundChannelPostback
 module.exports.handleInboundChannelMessage = handleInboundChannelMessage
@@ -343,7 +383,7 @@ module.exports.inboundFacebookMessengerEvent = inboundFacebookMessengerEvent
 module.exports.inboundFacebookWorkplaceEvent = inboundFacebookWorkplaceEvent
 module.exports.inboundFacebookWorkplaceInstallEvent = inboundFacebookWorkplaceInstallEvent
 module.exports.inboundFacebookWorkplaceUninstallEvent = inboundFacebookWorkplaceUninstallEvent
-
+module.exports.postEventToSource = postEventToSource
 module.exports.inboundNexmoEvent = inboundNexmoEvent
 module.exports.MESSAGE_TYPES = MESSAGE_TYPES
 module.exports.SOURCE_TYPE = SOURCE_TYPE

--- a/sessionsManager.js
+++ b/sessionsManager.js
@@ -62,6 +62,9 @@ const getAllActiveSessions = () => {
 				chatSessions[sessionID] = session
 				userChannelToSessions[session.source] = session
 			}
+			console.log("chatSessions", chatSessions);
+			console.log("userChannelToSessions", userChannelToSessions);
+
 		})
 		.catch(error => {
 			console.error("sessionsManager.getAllActiveSessions caught an error: " + error)
@@ -128,10 +131,10 @@ const clearChatSessions = (communityId) => {
 	chatSessions = {}
 	userChannelToSessions = {}
 
-	sessionsDb.removeSessionsByCommunity(communityId)
-	.then(() => {
-		return tokensDb.removeAccessToken(communityId)
-	})
+	// sessionsDb.removeSessionsByCommunity(communityId)
+	// .then(() => {
+	// 	return tokensDb.removeAccessToken(communityId)
+	// })
 
 }
 

--- a/sessionsManager.js
+++ b/sessionsManager.js
@@ -179,6 +179,7 @@ var getSessionByChannelEvent = (messagingEvent) => {
 			tokensDb.getAccessToken(communityId)
 			.then(json => {
 				var access_token = process.env.WORKPLACE_PAGE_ACCESS_TOKEN
+				console.log("USING WORKPLACE_PAGE_ACCESS_TOKEN", access_token)
 				if (json) {
 					access_token = json.access_token
 					mappedChatSession.communityAccessToken = json.access_token

--- a/sessionsManager.js
+++ b/sessionsManager.js
@@ -107,6 +107,10 @@ const inboundNexmoEvent = (req, res) => {
 	getChannel(CHANNELS.NEXMO).handleInboundEvent(req, res)
 }
 
+const inboundFacebookWorkplaceInstallEvent = (req, res) => {
+	return getChannel(CHANNELS.FB_WORKPLACE).handleInboundInstallEvent(req, res)
+}
+
 const getSessionBySessionId = sessionId => {
 	return chatSessions[sessionId]
 }
@@ -316,6 +320,7 @@ module.exports.getSessionBySessionId = getSessionBySessionId
 module.exports.getSessionByChannelEvent = getSessionByChannelEvent
 module.exports.inboundFacebookMessengerEvent = inboundFacebookMessengerEvent
 module.exports.inboundFacebookWorkplaceEvent = inboundFacebookWorkplaceEvent
+module.exports.inboundFacebookWorkplaceInstallEvent = inboundFacebookWorkplaceInstallEvent
 module.exports.inboundNexmoEvent = inboundNexmoEvent
 module.exports.MESSAGE_TYPES = MESSAGE_TYPES
 module.exports.SOURCE_TYPE = SOURCE_TYPE

--- a/sessionsManager.js
+++ b/sessionsManager.js
@@ -125,7 +125,6 @@ const getSessionBySessionId = sessionId => {
 
 const clearChatSessions = () => {
 	chatSessions = {}
-	channels = {}
 	userChannelToSessions = {}
 }
 

--- a/sessionsManager.js
+++ b/sessionsManager.js
@@ -186,7 +186,8 @@ var getSessionByChannelEvent = (messagingEvent) => {
 				var access_token = process.env.WORKPLACE_PAGE_ACCESS_TOKEN
 				console.log("USING WORKPLACE_PAGE_ACCESS_TOKEN", access_token)
 				if (json) {
-					mappedChatSession.community = json
+					access_token = json.access_token
+					mappedChatSession.communityAccessToken = json.access_token
 				} 
 				console.log("mappedChatSession", mappedChatSession)
 				userChannelToSessions[messagingEvent.source] = mappedChatSession

--- a/sessionsManager.js
+++ b/sessionsManager.js
@@ -123,6 +123,10 @@ const getSessionBySessionId = sessionId => {
 	return chatSessions[sessionId]
 }
 
+const clearChatSessions = () => {
+	chatSessions = []
+}
+
 /*
  * Return new or existing chat session Object.
  * 
@@ -402,3 +406,4 @@ module.exports.removeSessionBySource = removeSessionBySource
 module.exports.updateSession = updateSession
 module.exports.getApiAiAgent = getApiAiAgent
 module.exports.getDB = getDB
+module.exports.clearChatSessions = clearChatSessions

--- a/sessionsManager.js
+++ b/sessionsManager.js
@@ -124,7 +124,9 @@ const getSessionBySessionId = sessionId => {
 }
 
 const clearChatSessions = () => {
-	chatSessions = []
+	chatSessions = {}
+	channels = {}
+	userChannelToSessions = {}
 }
 
 /*

--- a/sessionsManager.js
+++ b/sessionsManager.js
@@ -124,7 +124,7 @@ const getSessionBySessionId = sessionId => {
 }
 
 const clearChatSessions = (communityId) => {
-	console.log("**Removing chat sessions for community")
+	console.log("**Removing chat sessions for community", communityId)
 	chatSessions = {}
 	userChannelToSessions = {}
 
@@ -184,7 +184,7 @@ var getSessionByChannelEvent = (messagingEvent) => {
 			}
 
 			if (messagingEvent.community ) {
-				mappedChatSession.community = messagingEvent.community
+				mappedChatSession.community = messagingEvent.community.toString()
 			}
 
 			var communityId = (typeof messagingEvent.community != "undefined") ? messagingEvent.community : null 

--- a/sessionsManager.js
+++ b/sessionsManager.js
@@ -416,4 +416,4 @@ module.exports.updateSession = updateSession
 module.exports.getApiAiAgent = getApiAiAgent
 module.exports.getDB = getDB
 module.exports.clearChatSessions = clearChatSessions
-
+module.exports.getAllActiveSessions = getAllActiveSessions

--- a/sessionsManager.js
+++ b/sessionsManager.js
@@ -124,6 +124,7 @@ const getSessionBySessionId = sessionId => {
 }
 
 const clearChatSessions = () => {
+	console.log("**Removing non-saved chat sessions")
 	chatSessions = {}
 	userChannelToSessions = {}
 }

--- a/sessionsManager.js
+++ b/sessionsManager.js
@@ -134,8 +134,23 @@ const clearChatSessions = (communityId) => {
 	.then(() => {
 		return tokensDb.removeAccessToken(communityId)
 	}).then(() => {
-		chatSessions = {}
-		userChannelToSessions = {}
+
+		//remove sessions from userChannelToSessions/chatSessions 
+		//when app is un-installed 
+		for (const session in userChannelToSessions) {
+			if (userChannelToSessions[session].community == communityId) {
+				console.log("removing session from  userChannelToSessions")
+				delete userChannelToSessions[session]
+			}
+		}
+	
+		for (const session in chatSessions) {
+			if (chatSessions[session].community == communityId) {
+				console.log("removing session from chatSessions")
+				delete chatSessions[session]
+			}
+		}
+		
 		getAllActiveSessions()
 	})
 

--- a/sessionsManager.js
+++ b/sessionsManager.js
@@ -340,15 +340,17 @@ const handleEvent = (session, event) => {
  * @param {*} eventFunction  //function to call to act on new session
  * @param {*} sourceType //source to post message to
  * @param {*} channel //channel to post message to
+ * @param {*} args //optional parameters that are passed into eventFunction
+
  */
-const postEventToSource = (sourceType, session, eventFunction, channel) => {
+const postEventToSource = (sourceType, session, eventFunction, args=null, channel) => {
 	return new Promise(resolve => {
         createSessionByEvent(session, sourceType, channel)
             .then(session => {
 					return new Promise(resolve => {
 						if (eventFunction) {
 							console.log("calling function ", eventFunction)
-							eventFunction(session)
+							eventFunction(session, args)
 							setTimeout(() => {
 								resolve(session)
 							}, 3000)

--- a/sessionsManager.js
+++ b/sessionsManager.js
@@ -183,7 +183,7 @@ var getSessionByChannelEvent = (messagingEvent) => {
 				mappedChatSession.community = messagingEvent.community
 			}
 
-			var communityId = (typeof messagingEvent.community != "undefined") ? messagingEvent.community.id : null 
+			var communityId = (typeof messagingEvent.community != "undefined") ? messagingEvent.community : null 
 			tokensDb.getAccessToken(communityId)
 			.then(json => {
 				var access_token = process.env.WORKPLACE_PAGE_ACCESS_TOKEN

--- a/sessionsManager.js
+++ b/sessionsManager.js
@@ -172,17 +172,19 @@ var getSessionByChannelEvent = (messagingEvent) => {
 			}
 
 			if (messagingEvent.community ) {
-				messagingEvent.community = messagingEvent.community
+				mappedChatSession.community = messagingEvent.community
 			}
 
 			var communityId = (typeof messagingEvent.community != "undefined") ? messagingEvent.community.id : null 
-			tokensDb.getAccessToken(communityId )
+			tokensDb.getAccessToken(communityId)
 			.then(json => {
+				console.log('tokensDb.getAccessToken json', json)
 				var access_token = process.env.WORKPLACE_PAGE_ACCESS_TOKEN
 				if (json) {
 					access_token = json.access_token
 					mappedChatSession.communityAccessToken = json.access_token
 				} 
+				console.log("mappedChatSession", mappedChatSession)
 				userChannelToSessions[messagingEvent.source] = mappedChatSession
 				return getChannel(mappedChatSession.channelType).getUserProfile(mappedChatSession.from, access_token)
 			})

--- a/sessionsManager.js
+++ b/sessionsManager.js
@@ -178,7 +178,6 @@ var getSessionByChannelEvent = (messagingEvent) => {
 			var communityId = (typeof messagingEvent.community != "undefined") ? messagingEvent.community.id : null 
 			tokensDb.getAccessToken(communityId)
 			.then(json => {
-				console.log('tokensDb.getAccessToken json', json)
 				var access_token = process.env.WORKPLACE_PAGE_ACCESS_TOKEN
 				if (json) {
 					access_token = json.access_token


### PR DESCRIPTION
For applications to be distributed by Facebook, we need to make a few adjustments.
First, and most important, the Access Token is UNIQUE between installs. Therefore, we cannot assume that WORKPLACE_PAGE_ACCESS_TOKEN in the env variables can be used. 

This PR retrieves the access token for the company from Firebase, saves the token to the Session, and uses that token for every FB API call. 